### PR TITLE
Add interface for specifying brancher labels and settings

### DIFF
--- a/src/BrancherServer.php
+++ b/src/BrancherServer.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypernode\DeployConfiguration;
+
+class BrancherServer extends Server
+{
+    public function getLabels(): array
+    {
+        return $this->getOptions()[self::OPTION_HN_BRANCHER_LABELS] ?? [];
+    }
+
+    /**
+     * @param string[] $labels Labels to be applied to the brancher node
+     * @return $this
+     */
+    public function setLabels(array $labels): self
+    {
+        $this->setOption(self::OPTION_HN_BRANCHER_LABELS, $labels);
+        return $this;
+    }
+
+    public function getSettings(): array
+    {
+        return $this->getOptions()[self::OPTION_HN_BRANCHER_SETTINGS] ?? [];
+    }
+
+    /**
+     * @param array $settings Settings to be applied to the brancher node
+     * @return $this
+     */
+    public function setSettings(array $settings): self
+    {
+        $this->setOption(self::OPTION_HN_BRANCHER_SETTINGS, $settings);
+        return $this;
+    }
+}

--- a/src/Server.php
+++ b/src/Server.php
@@ -8,6 +8,8 @@ namespace Hypernode\DeployConfiguration;
 class Server
 {
     public const OPTION_HN_BRANCHER = 'hn_brancher';
+    public const OPTION_HN_BRANCHER_LABELS = 'hn_brancher_labels';
+    public const OPTION_HN_BRANCHER_SETTINGS = 'hn_brancher_settings';
     public const OPTION_HN_PARENT_APP = 'hn_parent_app';
 
     /**
@@ -20,10 +22,7 @@ class Server
      */
     private $roles;
 
-    /**
-     * @var string[]
-     */
-    private $options = [];
+    private array $options;
 
     /**
      * @var string[]
@@ -32,7 +31,6 @@ class Server
 
     /**
      * @param string[] $roles
-     * @param string[] $options
      */
     public function __construct(string $hostname, array $roles = null, array $options = [])
     {
@@ -62,9 +60,6 @@ class Server
         return $this->roles;
     }
 
-    /**
-     * @return string[]
-     */
     public function getOptions(): array
     {
         return $this->options;
@@ -76,6 +71,16 @@ class Server
     public function getSshOptions(): array
     {
         return $this->sshOptions;
+    }
+
+    /**
+     * @param string $option
+     * @param mixed $value
+     * @return void
+     */
+    protected function setOption(string $option, $value)
+    {
+        $this->options[$option] = $value;
     }
 
     /**

--- a/src/Stage.php
+++ b/src/Stage.php
@@ -75,16 +75,18 @@ class Stage
      * @param array|null $roles Roles for the server to be applied
      * @param array $options Extra host options for Deployer
      * @see ServerRole
-     * @return Server
+     * @return BrancherServer
      */
-    public function addBrancherServer(string $appName, array $roles = null, array $options = []): Server
+    public function addBrancherServer(string $appName, array $roles = null, array $options = []): BrancherServer
     {
         $brancherOptions = [
             Server::OPTION_HN_BRANCHER => true,
             Server::OPTION_HN_PARENT_APP => $appName,
+            Server::OPTION_HN_BRANCHER_LABELS => [],
+            Server::OPTION_HN_BRANCHER_SETTINGS => [],
         ];
         $options = array_merge($brancherOptions, $options);
-        $server = new Server('', $roles, $options);
+        $server = new BrancherServer('', $roles, $options);
         $this->servers[] = $server;
         return $server;
     }

--- a/templates/deploy.magento2.php
+++ b/templates/deploy.magento2.php
@@ -14,6 +14,8 @@ $productionStage = $configuration->addStage('production', 'example.com');
 $productionStage->addServer('appname.hypernode.io');
 
 $testStage = $configuration->addStage('test', 'example.com');
-$testStage->addBrancherServer('appname');
+$testStage->addBrancherServer('appname')
+    ->setLabels(['stage=test', 'ci_ref=' . \getenv('GITHUB_RUN_ID') ?: 'none'])
+    ->setSettings(['cron_enabled' => false, 'supervisor_enabled' => false]);
 
 return $configuration;


### PR DESCRIPTION
The configuration can be done as follows:

```php
$testStage = $configuration->addStage('test', 'example.com');
$testStage->addBrancherServer('appname')
    ->setLabels(['stage=test', 'ci_ref=' . \getenv('GITHUB_REF') ?: 'none'])
    ->setSettings(['cron_enabled' => false, 'supervisor_enabled' => false]);
```

These labels can be used in Hypernode Deploy to determine what brancher nodes to clean up, for example: clean up brancher servers matching specified stage and their labels.