### PR TITLE
Fix shopware6 sw:build job

### DIFF
--- a/recipes/shopware6.php
+++ b/recipes/shopware6.php
@@ -71,7 +71,7 @@ task('sw:writable:jwt', static function () {
 });
 
 task('sw:build', static function () {
-    run('./bin/build.sh');
+    run('cd {{release_path}} && ./bin/build.sh');
 });
 
 task('sw:touch_install_lock', static function () {


### PR DESCRIPTION
`sw:build` is run in the deploy step, so we must execute `build.sh` from the release directory