### PR TITLE
shopware6: Make sure source files are deployed as well

### DIFF
--- a/src/ApplicationTemplate/Shopware6.php
+++ b/src/ApplicationTemplate/Shopware6.php
@@ -51,5 +51,19 @@ class Shopware6 extends Configuration
             'public/media',
             'public/thumbnail',
         ]);
+
+        // Override the default deploy exclude, because we need the source files (scss/ts)
+        // on the deploy step to compile the assets.
+        $this->setDeployExclude([
+            './.git',
+            './.github',
+            './deploy.php',
+            './.gitlab-ci.yml',
+            './Jenkinsfile',
+            '.DS_Store',
+            '.idea',
+            '.gitignore',
+            '.editorconfig',
+        ]);
     }
 }


### PR DESCRIPTION
Override the default deploy exclude, because we need the source files (scss/ts) on the deploy step to compile the assets.