### PR TITLE
composer: Bump psr/log version constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,6 @@
     },
     "require": {
         "deployer/deployer": "^7.0",
-        "psr/log": "^1.0"
+        "psr/log": "^1.0||^2.0||^3.0"
     }
 }


### PR DESCRIPTION
We support basically any version, so let's accept 2.x and 3.x as well