### PR TITLE
Logging: Fixup logger for psr/log 3.x

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -2,7 +2,7 @@
 
 namespace Hypernode\DeployConfiguration;
 
-use Hypernode\DeployConfiguration\Logging\SimpleLogger;
+use Hypernode\DeployConfiguration\Logging\LoggingFactory;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 
@@ -157,7 +157,7 @@ class Configuration
 
     public function __construct()
     {
-        $this->logger = new SimpleLogger(LogLevel::INFO);
+        $this->logger = LoggingFactory::create(LogLevel::INFO);
         $this->setDefaultComposerOptions();
     }
 

--- a/src/Logging/LegacyLogger.php
+++ b/src/Logging/LegacyLogger.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Hypernode\DeployConfiguration\Logging;
 
 use Psr\Log\AbstractLogger;
@@ -9,8 +7,9 @@ use Psr\Log\LogLevel;
 
 /**
  * Simple logger implementation using printf
+ * This logger was written for psr/log < 3.0.0.
  */
-class SimpleLogger extends AbstractLogger
+class LegacyLogger extends AbstractLogger
 {
     private const LEVEL_MAPPING = [
         LogLevel::DEBUG => 0,
@@ -34,17 +33,14 @@ class SimpleLogger extends AbstractLogger
     }
 
     /**
-     * Logs with an arbitrary level.
-     *
-     * @param mixed   $level
-     * @param string|\Stringable $message
-     * @param mixed[] $context
-     *
-     * @return void
+     * @param mixed $level 
+     * @param string|\Stringable $message 
+     * @param mixed[] $context 
+     * @return void 
      */
-    public function log($level, $message, array $context = []): void
+    public function log($level, $message, array $context = array())
     {
-        if ($this->mapLevelToNumber($level) >= $this->mappedLevel) {
+        if ($this->mapLevelToNumber($level) ?? 1 >= $this->mappedLevel) {
             printf("%s (%s)\n", $message, json_encode($context));
         }
     }

--- a/src/Logging/LoggingFactory.php
+++ b/src/Logging/LoggingFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypernode\DeployConfiguration\Logging;
+
+use Composer\InstalledVersions;
+use Psr\Log\LoggerInterface;
+
+class LoggingFactory
+{
+    public static function create(string $level): LoggerInterface
+    {
+        if (version_compare(InstalledVersions::getVersion('psr/log'), '3.0.0', '<')) {
+            return new LegacyLogger($level);
+        }
+        return new SimpleLogger($level);
+    }
+}


### PR DESCRIPTION
In #35 we updated the psr/log version, but apparently some things broke.

psr/log 3.x has added return types to all signatures, so that's why we need two different implementations of the same logger now.