### PR TITLE
shopware6: Set public folder to 'public'

### DIFF
--- a/src/ApplicationTemplate/Shopware6.php
+++ b/src/ApplicationTemplate/Shopware6.php
@@ -20,6 +20,7 @@ class Shopware6 extends Configuration
     private function initializeDefaultConfiguration(): void
     {
         $this->setRecipe('shopware6');
+        $this->setPublicFolder('public');
 
         $this->setComposerOptions([
             '--verbose',


### PR DESCRIPTION
The default is 'pub', it has to be 'public' for Shopware 6.