### PR TITLE
Disable the http:cache:warm:up step for Shopware 6.6+

### DIFF
--- a/recipes/shopware6.php
+++ b/recipes/shopware6.php
@@ -45,6 +45,13 @@ set('writable_dirs', [
     'var',
 ]);
 
+// This sets the shopware version to the version of the shopware console command.
+set('shopware_version', function () {
+    $versionOutput = run('cd {{release_path}} && bin/console -V');
+    preg_match('/(\d+\.\d+\.\d+\.\d+)/', $versionOutput, $matches);
+    return $matches[0] ?? '6.6.0';
+});
+
 task('sw:deploy:vendors_recovery', static function () {
     if (test('[ -d vendor/shopware/recovery ]')) {
         run('{{bin/composer}} {{composer_action}} -d vendor/shopware/recovery {{composer_options}} 2>&1');
@@ -60,7 +67,11 @@ task('sw:cache:clear', static function () {
 // visits the website, doesn't have to wait for the cache to be built up.
 task('sw:cache:warmup', static function () {
     run('cd {{release_path}} && bin/console cache:warmup');
-    run('cd {{release_path}} && bin/console http:cache:warm:up');
+
+    // Shopware 6.6+ dropped support for the http:cache:warmup command, so only execute it if the version is less than 6.6
+    if (version_compare(get('shopware_version'), '6.6.0') < 0) {
+        run('cd {{release_path}} && bin/console http:cache:warm:up');
+    }
 });
 
 // This task remotely executes the `database:migrate` console command on the target server.

--- a/recipes/shopware6.php
+++ b/recipes/shopware6.php
@@ -69,7 +69,7 @@ task('sw:cache:warmup', static function () {
     run('cd {{release_path}} && bin/console cache:warmup');
 
     // Shopware 6.6+ dropped support for the http:cache:warmup command, so only execute it if the version is less than 6.6
-    if (version_compare(get('shopware_version'), '6.6.0', '<')) {
+    if (version_compare(get('shopware_version'), '6.6.0', '<=')) {
         run('cd {{release_path}} && bin/console http:cache:warm:up');
     }
 });

--- a/recipes/shopware6.php
+++ b/recipes/shopware6.php
@@ -69,7 +69,7 @@ task('sw:cache:warmup', static function () {
     run('cd {{release_path}} && bin/console cache:warmup');
 
     // Shopware 6.6+ dropped support for the http:cache:warmup command, so only execute it if the version is less than 6.6
-    if (version_compare(get('shopware_version'), '6.6.0') < 0) {
+    if (version_compare(get('shopware_version'), '6.6.0', '<')) {
         run('cd {{release_path}} && bin/console http:cache:warm:up');
     }
 });


### PR DESCRIPTION
"Backport" the changes from https://github.com/deployphp/deployer/pull/4041